### PR TITLE
Implement centralized API calls and update routing

### DIFF
--- a/frontend/app/plugins/api.ts
+++ b/frontend/app/plugins/api.ts
@@ -1,0 +1,31 @@
+import { useRequestHeaders } from '#app';
+
+export default defineNuxtPlugin(() => ({
+  provide: {
+    apiCall: async <T>(url: string, options: any = {}): Promise<T> => {
+      const headers = import.meta.server ? useRequestHeaders(['cookie']) : undefined;
+      const API_BASE_URL = 'http://localhost:3001';
+
+      const doFetch = () =>
+        $fetch<T>(`${API_BASE_URL}${url}`, {
+          ...options,
+          headers,
+          credentials: 'include',
+        });
+
+      try {
+        return await doFetch();
+      } catch (error: any) {
+        if (error?.status === 401) {
+          await $fetch(`${API_BASE_URL}/auth/refresh`, {
+            method: 'POST',
+            headers,
+            credentials: 'include',
+          });
+          return await doFetch();
+        }
+        throw error;
+      }
+    },
+  },
+}));

--- a/frontend/app/utils/api.ts
+++ b/frontend/app/utils/api.ts
@@ -27,39 +27,5 @@ export class ApiService {
     return await $fetch<string>(`${API_BASE_URL}/`);
   }
 
-  static async refreshToken(): Promise<{ success: boolean }> {
-    return await $fetch(`${API_BASE_URL}/auth/refresh`, {
-      method: 'POST',
-      credentials: 'include',
-    });
-  }
 
-  static async apiCall<T>(url: string, options: any = {}): Promise<T> {
-    const headers = import.meta.server ? useRequestHeaders(['cookie']) : undefined
-    try {
-    return await $fetch<T>(`${API_BASE_URL}${url}`, {
-        ...options,
-        headers,
-        credentials: 'include',
-    });
-    } catch (error: any) {
-    // If 401 (Token expired), try refresh
-    if (error.status === 401) {
-        try {
-        await this.refreshToken();
-        // Retry with new Token
-        return await $fetch<T>(`${API_BASE_URL}${url}`, {
-            ...options,
-            credentials: 'include',
-        });
-        } catch (refreshError) {
-        // Refresh failed, log user out
-        const authStore = useAuthStore();
-        authStore.logout();
-        throw refreshError;
-        }
-    }
-    throw error;
-    }
-}
 }

--- a/frontend/app/utils/apis/auth.ts
+++ b/frontend/app/utils/apis/auth.ts
@@ -30,12 +30,16 @@ export type TCreateUserDto = {
   }
 export const authApi = {
     login(data: TSignInDto): Promise<TSignInResponse> {
-        return ApiService.apiCall('/auth', {method: 'POST', body: data});
+      const {$apiCall} = useNuxtApp();
+      return $apiCall('/auth', {method: 'POST', body: data})
+       /*  return ApiService.apiCall('/auth', {method: 'POST', body: data}); */
     },
     logout(): Promise<{ok:boolean}>{
-        return ApiService.apiCall('/auth/logout', {method: 'POST'});
+      const {$apiCall} = useNuxtApp();
+        return $apiCall('/auth/logout', {method: 'POST'});
     },
     createUser(data: TCreateUserDto): Promise<TCreateUserResponse> {
-        return ApiService.apiCall('/user', {method: 'POST', body: data});
+      const {$apiCall} = useNuxtApp();
+        return $apiCall('/user', {method: 'POST', body: data});
     }
 }

--- a/frontend/app/utils/apis/user.ts
+++ b/frontend/app/utils/apis/user.ts
@@ -1,5 +1,5 @@
 
-import { ApiService } from '~/utils/api';
+
 export type TUser =  {
     id: string;
     email: string;
@@ -17,9 +17,11 @@ export type TUser =  {
   }
 export const userApi = {
     get():Promise<TUser> {
-        return ApiService.apiCall('/user/profile', {method: 'GET'})
+        const {$apiCall} = useNuxtApp();
+        return $apiCall('/user/profile', {method: 'GET'})
     },
     update(data: TUpdateUserDto): Promise<TUser>{
-        return ApiService.apiCall('/user/update', {method: 'POST', body: data})
+        const {$apiCall} = useNuxtApp();
+        return $apiCall('/user/update', {method: 'POST', body: data})
     }
 }

--- a/frontend/docs/apiCallFunctionWrapper.md
+++ b/frontend/docs/apiCallFunctionWrapper.md
@@ -1,82 +1,147 @@
-# idea to encapsulate and centralize the api calls for specific domains
-The Idea ist that we call one function in the `utils/api` directory that takes 2 parameters url and options({method: 'GET'})
-The function creates a refresh token httpOnly cookie or if the access_token is expired or both are invalid loggs the user out of the application.
+# Centralized API calls via Nuxt plugin `$apiCall`
 
-- create domain specific api calls for example:
-    - Domäne „Appointments”:
-        appointmentsApi.list() → gets all appointments
-        appointmentsApi.get(id) → gets one appointment
-        appointmentsApi.create(payload) →  creates a appointment
-        appointmentsApi.update(id, payload) → change one appointment
-        appointmentsApi.delete(id) →  delete one appointment
+This document explains how we centralize HTTP calls through a Nuxt plugin that provides `$apiCall`. It also shows how to access it with `const { $apiCall } = useNuxtApp()` and how to use it in domain APIs and Pinia stores.
 
-## The `apiCall()` function:
-```TS
-    static async apiCall<T>(url: string, options: any = {}): Promise<T> {
-        try {
-        return await $fetch<T>(`${API_BASE_URL}${url}`, {
-            ...options,
+- **Goal**: One place to handle credentials, SSR cookies, and refresh-token retries.
+- **Behavior**: On 401, it calls `/auth/refresh` (httpOnly cookie-based), then retries the original request. If refresh fails, the caller can handle logout.
+
+## 1) Nuxt plugin that provides `$apiCall`
+
+Create `app/plugins/api.ts`:
+
+```ts
+import { useRequestHeaders } from '#app'
+
+export default defineNuxtPlugin(() => ({
+  provide: {
+    apiCall: async <T>(url: string, options: any = {}): Promise<T> => {
+      const headers = import.meta.server ? useRequestHeaders(['cookie']) : undefined
+      const API_BASE_URL = 'http://localhost:3001'
+
+      const doFetch = () =>
+        $fetch<T>(`${API_BASE_URL}${url}`, {
+          ...options,
+          headers,
+          credentials: 'include',
+        })
+
+      try {
+        return await doFetch()
+      } catch (error: any) {
+        if (error?.status === 401) {
+          await $fetch(`${API_BASE_URL}/auth/refresh`, {
+            method: 'POST',
+            headers,
             credentials: 'include',
-        });
-        } catch (error: any) {
-        // If 401 (Token expired), try refresh
-        if (error.status === 401) {
-            try {
-            await this.refreshToken();
-            // Retry with new Token
-            return await $fetch<T>(`${API_BASE_URL}${url}`, {
-                ...options,
-                credentials: 'include',
-            });
-            } catch (refreshError) {
-            // Refresh failed, log user out
-            const authStore = useAuthStore();
-            authStore.logout();
-            throw refreshError;
-            }
+          })
+          return await doFetch()
         }
-        throw error;
-        }
-    }
-```
-## A practical code Example:
-
-``` TS
-    /app/utils/apis/appointments.ts
-    import { ApiService } from '~/app/utils/api'
-
-    export const appointmentsApi = {
-        list() {
-            return ApiService.apiCall('/appointments', { method: 'GET' })
-        },
-        get(id: string) {
-            return ApiService.apiCall(`/appointments/${id}`, { method: 'GET' })
-        },
-        create(payload: { title: string; at: string }) {
-            return ApiService.apiCall('/appointments', { method: 'POST', body: payload })
-        },
-        update(id: string, payload: any) {
-            return ApiService.apiCall(`/appointments/${id}`, { method: 'PUT', body: payload })
-        },
-        delete(id: string) {
-            return ApiService.apiCall(`/appointments/${id}`, { method: 'DELETE' })
-        },
-    }
+        throw error
+      }
+    },
+  },
+}))
 ```
 
-The API calls are then called up in the corresponding stores. Like `appointmentStore`
-```TS
-    // stores/appointments/appointmentsStore.ts
-    import { defineStore } from 'pinia'
-    import { appointmentsApi } from '~/app/apis/appointments'
+Notes:
+- `credentials: 'include'` ensures cookies are sent (access/refresh tokens are httpOnly cookies).
+- On SSR, `useRequestHeaders(['cookie'])` forwards incoming request cookies to the backend.
 
-    export const useAppointmentsStore = defineStore('appointments', () => {
-        const items = ref<any[]>([])
+## 2) Access `$apiCall` with `useNuxtApp()`
 
-        async function load() {
-            items.value = await appointmentsApi.list()
-        }
+Always access the plugin inside setup-context code (components, composables, stores, middleware, plugins). Example:
 
-        return { items, load }
-    })
+```ts
+const { $apiCall } = useNuxtApp()
+await $apiCall('/health', { method: 'GET' })
 ```
+
+Do not call `useNuxtApp()` at module top-level. Call it inside functions/actions.
+
+## 3) Domain API modules using `$apiCall`
+
+Example `app/utils/apis/auth.ts`:
+
+```ts
+export type TSignInDto = { email: string; password: string }
+
+export const authApi = {
+  async login(data: TSignInDto) {
+    const { $apiCall } = useNuxtApp()
+    return $apiCall('/auth', { method: 'POST', body: data })
+  },
+  async logout() {
+    const { $apiCall } = useNuxtApp()
+    return $apiCall('/auth/logout', { method: 'POST' })
+  },
+  async status() {
+    const { $apiCall } = useNuxtApp()
+    return $apiCall('/auth/status', { method: 'GET' })
+  },
+}
+```
+
+Example `app/utils/apis/user.ts`:
+
+```ts
+export type TUser = {
+  id: string
+  email: string
+  first_name: string
+  last_name: string
+  phone: string
+}
+
+export type TUpdateUserDto = {
+  email?: string
+  first_name?: string
+  last_name?: string
+  phone?: string
+  password?: string
+}
+
+export const userApi = {
+  async get(): Promise<TUser> {
+    const { $apiCall } = useNuxtApp()
+    return $apiCall<TUser>('/user/profile', { method: 'GET' })
+  },
+  async update(data: TUpdateUserDto): Promise<TUser> {
+    const { $apiCall } = useNuxtApp()
+    return $apiCall<TUser>('/user/update', { method: 'POST', body: data })
+  },
+}
+```
+
+## 4) Using in Pinia stores
+
+Use domain APIs inside store actions. Do not call `useNuxtApp()` at the top level of the module.
+
+```ts
+// stores/user/userStore.ts
+import { defineStore } from 'pinia'
+import { userApi, type TUser, type TUpdateUserDto } from '~/utils/apis/user'
+
+export const useUserStore = defineStore('user', () => {
+  const user = ref<TUser | null>(null)
+
+  async function getUser() {
+    const profile = await userApi.get()
+    user.value = profile
+    return profile
+  }
+
+  async function updateUser(data: TUpdateUserDto) {
+    const profile = await userApi.update(data)
+    user.value = profile
+    return profile
+  }
+
+  return { user, getUser, updateUser }
+})
+```
+
+## 5) Why a plugin and not direct `$fetch` everywhere?
+
+- Single place to handle refresh-token retries and credentials.
+- SSR cookie forwarding handled centrally.
+- Cleaner domain APIs and store actions.

--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -20,7 +20,9 @@ export default defineNuxtConfig({
       },
     },
   },
-
+  routeRules: {
+    '/': {redirect: '/login'}
+  },
   runtimeConfig: {
     public: {
       apiBase: 'http://localhost:3001',

--- a/frontend/stores/auth/authStore.ts
+++ b/frontend/stores/auth/authStore.ts
@@ -1,5 +1,6 @@
 import { defineStore } from 'pinia';
-import { ApiService } from '~/utils/api';
+/* import { ApiService } from '~/utils/api'; */
+
 import { ref } from 'vue';
 import { authApi, type TCreateUserDto, type TSignInDto } from '~/utils/apis/auth';
 
@@ -7,25 +8,26 @@ export const useAuthStore = defineStore('auth', () => {
     const isAuthenticated = ref<boolean>(false);
 
     async function checkAuthStatus() {
-        try {
-           await ApiService.apiCall('/auth/status');
-          isAuthenticated.value = true;
-          return true;
-        } catch (error) {
-          isAuthenticated.value = false;
-          return false;
-        }
+      try {
+        const {$apiCall} = useNuxtApp()
+        await $apiCall('/auth/status')
+        isAuthenticated.value = true;
+        return true;
+      } catch (error) {
+        isAuthenticated.value = false;
+        return false;
       }
+    }
     async function logout() {
-        try {
-          return authApi.logout()
-        } catch (error) {
-          console.error('Logout error:', error);
-          isAuthenticated.value = false
-        } finally {
-          isAuthenticated.value = false;
-        }
+      try {
+        return authApi.logout()
+      } catch (error) {
+        console.error('Logout error:', error);
+        isAuthenticated.value = false
+      } finally {
+        isAuthenticated.value = false;
       }
+    }
 
       function registerUser(data: TCreateUserDto){
         return authApi.createUser(data);

--- a/frontend/stores/user/userStore.ts
+++ b/frontend/stores/user/userStore.ts
@@ -7,6 +7,7 @@ export const useUserStore = defineStore('user', ()=> {
 
     async function getUser(){
     try {
+
         const profile = await userApi.get();
 
         if (profile) {


### PR DESCRIPTION
- Introduced a new Nuxt plugin to centralize API calls via `$apiCall`, improving error handling and refresh-token management.
- Updated the `authApi` and `userApi` to utilize the new `$apiCall` method for making requests, enhancing code consistency.
- Deleted the `ApiService` methods apiCall and refresh api call
- Added route rules to redirect users to the login page on accessing the root route.